### PR TITLE
fix(nav): changed “OS Contributors” to “Contributors”, removed Media

### DIFF
--- a/_includes/partial/site-footer.html
+++ b/_includes/partial/site-footer.html
@@ -9,11 +9,9 @@
     <a href="{{ site.github.url }}/service-integrators"
        class="site-nav__item">Service Integrators</a>
     <a href="{{ site.github.url }}/contributors"
-       class="site-nav__item">OS Contributors</a>
+       class="site-nav__item">Contributors</a>
     <a href="{{ site.github.url }}/events"
        class="site-nav__item">Events</a>
-    <a href="{{ site.github.url }}/media"
-       class="site-nav__item">Media</a>
     <a href="{{ site.github.url }}/partners"
        class="site-nav__item">Partners</a>
     <a href="{{ site.github.url }}/faq"

--- a/_includes/partial/site-header.html
+++ b/_includes/partial/site-header.html
@@ -16,11 +16,9 @@
       <a href="{{ site.github.url }}/service-integrators"
          class="site-nav__item site-nav__item--main">Service Integrators</a>
       <a href="{{ site.github.url }}/contributors"
-         class="site-nav__item site-nav__item--main">OS Contributors</a>
+         class="site-nav__item site-nav__item--main">Contributors</a>
       <a href="{{ site.github.url }}/events"
          class="site-nav__item site-nav__item--main">Events</a>
-      <a href="{{ site.github.url }}/media"
-         class="site-nav__item site-nav__item--main">Media</a>
       <a href="{{ site.github.url }}/partners"
          class="site-nav__item site-nav__item--main">Partners</a>
       <a href="{{ site.github.url }}/faq"


### PR DESCRIPTION
Updated the nav to use Contributors only.

Also: the Media page is no longer a thing.

fixes #40
fixes #43