### PR TITLE
Local development fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,18 @@
 
 OpenWhisk is a cloud-first distributed event-based programming service. It provides a programming model to upload event handlers to a cloud service, and register the handlers to respond to various events.
 
+## Quickstart for Local Development
+
+``` sh
+# Clone the repository (and correct branch).
+git clone https://github.com/openwhisk/openwhisk.github.io.git
+
+# Move into the cloned repo.
+cd openwhisk.github.io
+
+# Start the development server.
+bin/develop
+```
 
 ### License
 

--- a/bin/develop
+++ b/bin/develop
@@ -1,10 +1,3 @@
 #!/bin/bash
 
-export SSL="true"
-export JEKYLL_GITHUB_TOKEN='5f411973a44b84b54d7af7aee4a4a1884a561adf'
-export PAGES_REPO_NWO='bluemix/develop.ibm.com-openwhisk'
-export OCTOKIT_API_ENDPOINT='https://github.ibm.com/api/v3'
-export OCTOKIT_WEB_ENDPOINT='https://github.ibm.com'
-export PAGES_PAGES_HOSTNAME='https://pages.github.ibm.com'
-
 bundle exec jekyll serve


### PR DESCRIPTION
1. Removed environment variables from the `develop` script. Fixes #47 
2. Updated README with a quickstart section. Addresses #38 