### PR TITLE
fix(contact): added line breaks to avoid email wrapping

### DIFF
--- a/contact.md
+++ b/contact.md
@@ -1,5 +1,6 @@
 ---
-title: Contact — Apache OpenWhisk
+title: Contact
+seo_title: Contact — Apache OpenWhisk
 ---
 
 The Dev Mailing List is where we discuss the development of Apache OpenWhisk. It is _not_ a place for technical support; if you're looking for help on a project, check out the [`#openwhisk` tag on Stack Overflow](http://stackoverflow.com/questions/tagged/openwhisk).
@@ -8,13 +9,13 @@ The Dev Mailing List is where we discuss the development of Apache OpenWhisk. It
 
 **NOTE:** Make sure you add a subject line to the subscribe/unsubscribe messages. Empty emails are ignored.
 
-To subscribe to the list, send a message to:
-   <dev-subscribe@openwhisk.incubator.apache.org>
+To subscribe to the list, send a message to:<br>
+<dev-subscribe@openwhisk.incubator.apache.org>
 
-To remove your address from the list, send a message to:
-   <dev-unsubscribe@openwhisk.incubator.apache.org>
+To remove your address from the list, send a message to:<br>
+<dev-unsubscribe@openwhisk.incubator.apache.org>
 
-To create a new thread, send a message to:
-   <dev@openwhisk.incubator.apache.org>
+To create a new thread, send a message to:<br>
+<dev@openwhisk.incubator.apache.org>
 
 To comment on a thread, reply to the message.


### PR DESCRIPTION
This is nitpicky, but I think it helps legibility.

Also added an SEO title while I was in there.