### PR TITLE
fix(open source): remove hyphenation from “open source”

### DIFF
--- a/_layouts/contributors.html
+++ b/_layouts/contributors.html
@@ -82,7 +82,7 @@ layout: default
         </h2>
         <p class="main-content__text">
           Pad your resume by contributing to bleeding-edge, serverless
-          technology. Become part of a growing community of open-source
+          technology. Become part of a growing community of open source
           developers working to improve Apache OpenWhisk. Propose a feature,
           submit a pull request, or create a tutorial — help build a movement!
         </p>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -204,7 +204,7 @@ layout: default
         <div class="persona__column">
           <img class="persona__benefit-image"
                src="{{ site.github.url }}/images/illustration-contributors.svg"
-               alt="Apache OpenWhisk benefits for open-source contributors">
+               alt="Apache OpenWhisk benefits for open source contributors">
         </div>
         <div class="persona__column">
           <h2 class="persona__heading">Join a vibrant open source community.</h2>

--- a/_layouts/integrators.html
+++ b/_layouts/integrators.html
@@ -99,7 +99,7 @@ layout: default
     <blockquote id="quote1" class="quotes__quote quotes__quote--js-fader">
       <div class="quotes__text">
         <p>
-          “What excites me most [about Apache OpenWhisk] is its open-source
+          “What excites me most [about Apache OpenWhisk] is its open source
           nature, which creates a foundation for a broad ecosystem of
           contributing parties.”
         </p>

--- a/about.md
+++ b/about.md
@@ -4,10 +4,11 @@ title: What Is Apache OpenWhisk?
 youtube_video_id: enk45wEQHzI
 ---
 
-Apache OpenWhisk is a [serverless]({{ site.github.url }}/serverless), open-source cloud platform that allows you to execute code in response to events at any scale. We handle the infrastructure and servers — you can focus on building amazing things.
+Apache OpenWhisk is a [serverless]({{ site.github.url }}/serverless), open 
+source cloud platform that allows you to execute code in response to events at any scale. We handle the infrastructure and servers — you can focus on building amazing things.
 
 Apache OpenWhisk allows [developers]({{ site.github.url }}/developers) to focus on writing value-adding code instead of burning hours on architecture and server management. Write in your preferred language to combine custom code with plug-and-play packages from our rich ecosystem of partner services, and go live in hours instead of weeks.
 
 [Service integrators]({{ site.github.url }}/service-integrators) can easily add their service to Apache OpenWhisk’s growing ecosystem to eliminate the need to build in-house solutions for third-party integrations, reach a broader community of developers, and increase adoption of their products and services.
 
-The Apache OpenWhisk community is driven by [open-source contributors]({{ site.github.url }}/contributors) who are advancing this bleeding-edge technology, growing their skillsets, and pushing the boundaries of serverless technology.
+The Apache OpenWhisk community is driven by [open source contributors]({{ site.github.url }}/contributors) who are advancing this bleeding-edge technology, growing their skillsets, and pushing the boundaries of serverless technology.

--- a/faq.md
+++ b/faq.md
@@ -18,11 +18,11 @@ OpenWhisk abstracts away all infrastructure and operational concerns, allowing d
 
 ### How is it open?
 
-OpenWhisk has been made available as open-source to encourage others to participate to accelerate its development and to help generating a powerful ecosystem of event providers and consumers.
+OpenWhisk has been made available as open source to encourage others to participate to accelerate its development and to help generating a powerful ecosystem of event providers and consumers.
 
 ### Which offerings are available?
 
-OpenWhisk is available – currently as experimental offering – for IBM Bluemix that can be found [here](https://console.ng.bluemix.net/openwhisk/) as well as open-source offering that can be found [here](https://github.com/openwhisk/openwhisk).
+OpenWhisk is available – currently as experimental offering – for IBM Bluemix that can be found [here](https://console.ng.bluemix.net/openwhisk/) as well as open source offering that can be found [here](https://github.com/openwhisk/openwhisk).
 
 ### Can I enable my own services for OpenWhisk?
 
@@ -44,7 +44,7 @@ We have a collection of blog posts available [on Medium](https://medium.com/open
 
 Absolutely. Videos can be found [on YouTube](https://www.youtube.com/channel/UCbzgShnQk8F43NKsvEYA1SA). We also have a collection of [resources on GitHub](https://github.com/openwhisk/awesome-openwhisk/) to help get you started.
 
-### Who are the OpenWhisk open-source partners?
+### Who are the OpenWhisk open source partners?
 
 Check out our [partners page]({{ site.github.url }}/partners) for information about Apache OpenWhisk partners.
 


### PR DESCRIPTION
Done ~~grudgingly~~ cheerily after the discussion on #120.

closes #120 (and I died a little inside)